### PR TITLE
Store IDs as integer in JSON export

### DIFF
--- a/clean_participants.py
+++ b/clean_participants.py
@@ -4,9 +4,10 @@ import fire
 
 from wsgi import get_export_dir, read_ak_data, write_ak_data
 
+
 def fix_id_type(
     data_lst: list[dict],
-    clz=str,
+    clz=int,
     id_key: str = "id",
     filter_fn=None,
     replace_fn=None,

--- a/create_solver_input.py
+++ b/create_solver_input.py
@@ -17,14 +17,16 @@ def construct_solver_json(
 
     for idx, ak in enumerate(data["aks"]):
         if "id" not in ak:
-            ak["id"] = f"ak{idx}"
+            ak["id"] = idx
         ak["properties"] = {}
 
     participants = []
-    for result_json in get_export_dir(poll_name).glob("*.json"):
+    for participant_idx, result_json in enumerate(
+        get_export_dir(poll_name).glob("*.json")
+    ):
         with result_json.open("r") as ff:
             result_dict = json.load(ff)
-        result_dict["id"] = result_json.stem
+        result_dict["id"] = participant_idx
         if fixed_preferences:
             result_dict["preferences"].extend(fixed_preferences)
         participants.append(result_dict)

--- a/wsgi.py
+++ b/wsgi.py
@@ -95,7 +95,7 @@ def post_result(poll_name: str):
                         f"Got '{preference_score}'"
                     )
 
-                ak_id = str(int(key[len(app.config["AK_PREFIX"]) :]))
+                ak_id = int(key[len(app.config["AK_PREFIX"]) :])
                 participant["preferences"].append(
                     {
                         "ak_id": ak_id,
@@ -236,7 +236,7 @@ def show_results(poll_name: str):
                 result_dict = json.load(ff)
             for pref in result_dict["preferences"]:
                 ak_id = pref["ak_id"]
-                if ak_id.startswith(app.config["AK_PREFIX"]):
+                if isinstance(ak_id, str) and ak_id.startswith(app.config["AK_PREFIX"]):
                     ak_id = ak_id[len(app.config["AK_PREFIX"]) :]
                 ak_id = int(ak_id)
                 ak_name = ak_list[ak_id]["info"]["name"]


### PR DESCRIPTION
This change accompanies [pull request 16 in the KoMa-solver repo](https://github.com/Die-KoMa/ak-plan-optimierung/pull/16). The datatype of IDs is changed from string to int.